### PR TITLE
Swapped Thread Operations

### DIFF
--- a/Slave/Slave_Main/Operator.cpp
+++ b/Slave/Slave_Main/Operator.cpp
@@ -4,6 +4,8 @@
 Operator::Operator()
 {
   pattern = &Patterns::Solid_Color;
+  t = new Thread;
+  t->start(mbed::callback(Operator::runPattern));
 }
 
 void Operator::readSerial() 
@@ -16,6 +18,8 @@ void Operator::readSerial()
 
     Serial.println(code);
     
+    t->terminate();
+    t = new Thread;
 
     if (code.charAt(0) == 'C')
       processColor(code);
@@ -23,6 +27,8 @@ void Operator::readSerial()
       processMusicPattern(code);
     else if (code.charAt(0) == 'S')
       processStaticPattern(code);
+
+      t->start(mbed::callback(Operator::runPattern));
   }
 }
 

--- a/Slave/Slave_Main/Operator.h
+++ b/Slave/Slave_Main/Operator.h
@@ -21,6 +21,7 @@ class Operator
     static void runPattern();
 
   private:
+    Thread* t;
 
     static void (*pattern)(void);
 

--- a/Slave/Slave_Main/Slave_Main.ino
+++ b/Slave/Slave_Main/Slave_Main.ino
@@ -6,8 +6,6 @@ using namespace rtos;
 #define NumLeds 300
 #define AUDIO_PIN A2
 
-Thread t;
-
 Adafruit_NeoPixel pixels(NumLeds, LED_PIN, NEO_GRB + NEO_KHZ800);
 
 int LED_Controller::num_leds = NumLeds;
@@ -24,12 +22,6 @@ int Patterns::b = 0;
 void (*Operator::pattern)(void) = &Patterns::Solid_Color;
 
 Operator Op;
-void thread(void) {
-  while(1) {
-    Op.readSerial();
-  }
-  
-}
 
 void setup() {
   // put your setup code here, to run once:
@@ -43,15 +35,8 @@ void setup() {
   //Start LEDS
   pixels.begin();
   pixels.setBrightness(50);
-
-  //Start Thread
-  t.start(mbed::callback(thread));
-
 }
 
 void loop() {
-  //Op.runPattern();
-  Serial.println("Main Thead");
-  delay(500);
-  Operator::runPattern();
+  Op.readSerial();
 }

--- a/Slave/Slave_Main/patterns.cpp
+++ b/Slave/Slave_Main/patterns.cpp
@@ -1,6 +1,6 @@
 #include "patterns.h"
 
-Patterns::Patterns(LED_Controller* L, AudioProcessor* P)b         
+Patterns::Patterns(LED_Controller* L, AudioProcessor* P)
 {
 
   r = 0;


### PR DESCRIPTION
Moved Patterns to running on the side thread, serial reading occurs now on the main thread. This is done to allow the system to respond to changes immediately. The system can now cancel the pattern when a change occurs, and implement that change right away. All of the threading is now handled internally by the Operator class.